### PR TITLE
feat: upgrade providers versions and use new tfe_workspace_variable_set resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Terraform module to provision and manage Terraform Cloud variable sets
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.31.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >= 0.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.31.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | >= 0.39.0 |
 
 ## Modules
 
@@ -25,6 +25,7 @@ No modules.
 |------|------|
 | [tfe_variable.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable_set.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable_set) | resource |
+| [tfe_workspace_variable_set.this](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_variable_set) | resource |
 
 ## Inputs
 
@@ -41,7 +42,7 @@ No modules.
 | <a name="input_terraform_sensitive_variables"></a> [terraform\_sensitive\_variables](#input\_terraform\_sensitive\_variables) | (Optional) Map of sensitive variables of 'Terraform' category used in the variable set<br><br>Item syntax:<br>{<br>  variable1\_name = value1<br>  variable2\_name = value2<br>  ...<br>} | `map(any)` | `{}` | no |
 | <a name="input_terraform_variables"></a> [terraform\_variables](#input\_terraform\_variables) | (Optional) Map of variables of 'Terraform' category used in the workspace<br><br>  Item syntax:<br>  {<br>    variable1\_name = value1<br>    variable2\_name = value2<br>    ...<br>  } | `map(any)` | `{}` | no |
 | <a name="input_variables_descriptions"></a> [variables\_descriptions](#input\_variables\_descriptions) | (Optional) Map of descriptions applied to variable set variables<br><br>  Item syntax:<br>  {<br>    variable1\_name = "description"<br>    variable2\_name = "description"<br>    ...<br>  } | `map(string)` | `{}` | no |
-| <a name="input_workspace_ids"></a> [workspace\_ids](#input\_workspace\_ids) | (Optional) IDs of the workspaces that use the variable set. Must not be set if global is set | `list(string)` | `[]` | no |
+| <a name="input_workspace_ids"></a> [workspace\_ids](#input\_workspace\_ids) | (Optional) IDs of the workspaces that use the variable set. Must not be set if global is true | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,13 +30,13 @@ Choose the appropriate method to automatically specify these values, like descri
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.2.0 |
-| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.31.0 |
+| <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | ~> 0.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.31.0 |
+| <a name="provider_tfe"></a> [tfe](#provider\_tfe) | ~> 0.39.0 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.31.0"
+      version = "~> 0.39.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -68,11 +68,7 @@ resource "tfe_variable_set" "this" {
   name         = var.name
   description  = var.description
   organization = var.organization
-
-  #NOTE: these two attributes are mutually exclusive
-  #      See https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable_set#argument-reference)
-  global        = length(var.workspace_ids) > 0 ? null : var.global
-  workspace_ids = var.global ? null : var.workspace_ids
+  global       = var.global
 }
 
 resource "tfe_variable" "this" {
@@ -85,4 +81,11 @@ resource "tfe_variable" "this" {
   description     = try(each.value.description, null)
   sensitive       = try(each.value.sensitive, false)
   variable_set_id = tfe_variable_set.this.id
+}
+
+resource "tfe_workspace_variable_set" "this" {
+  count = length(var.workspace_ids)
+
+  variable_set_id = tfe_variable_set.this.id
+  workspace_id    = var.workspace_ids[count.index]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "global" {
 }
 
 variable "workspace_ids" {
-  description = " (Optional) IDs of the workspaces that use the variable set. Must not be set if global is set"
+  description = " (Optional) IDs of the workspaces that use the variable set. Must not be set if global is true"
   type        = list(string)
   default     = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = ">= 1.0.0"
 
   required_providers {
     tfe = {
       source  = "hashicorp/tfe"
-      version = "~> 0.31.0"
+      version = ">= 0.39.0"
     }
   }
 }


### PR DESCRIPTION
Upgrade tfe provider version to latest stable 0.39.x, that add a new tfe_workspace_variable_set, that replaces the inline "workspace_ids" attribute of "tfe_variable_set"

See https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/workspace_variable_set

I enforced the use of the initial stable version of Terraform (>=1.0.0)

I evaluate to enforce a newer version in next releases in order to use specific new features (for example the optional attributes https://github.com/hashicorp/terraform/blob/v1.3/CHANGELOG.md#130-september-21-2022)